### PR TITLE
Multiple changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ These values must be set.  They correspond to:
 
 Optional configuration values include:
 
-* USE_PLEXPASS - If set to 1, the script will download and install the PlexPass version of Plex Media Server.  Defaults to 0.
+* USE_PLEXPASS - If set to 1, the script will download and install the beta version of Plex Media Server. Note that all PlexPass features are available in the stable version, as well. Defaults to 0.
 * PLEX_CONFIG_PATH - The path to store your Plex metadata and configuration.  Defaults to `$POOL_PATH/plex_data`.
+* NETMASK - The netmask, in bits, for the network the Plex jail will be on. Defaults to '24', which is '255.255.255.0'.
 
 $PLEX_CONFIG_PATH need not exist before running this script; if it doesn't, the script will create it.  The script will also set ownership of that directory to the user/group IDs for Plex Media Server.  If this directory already exists, it **must not** be using Windows permissions.
 
 Note that if the script creates $PLEX_CONFIG_PATH, it will create it as a **directory**, not as a dataset.  This means that it will not appear in, e.g., the Storage section of the FreeNAS GUI, where you could easily see how much space it's using, compression ratio, etc.  If you want these capabilities, you should create the dataset before running the script, and then ensure that $PLEX_CONFIG_PATH is set appropriately.
 
 Once you've prepared the configuration file, run the script by running `./plex-jail.sh`.  It should run for a few minutes and report completion.  You can then add storage to your jail as desired (see [Uncle Fester's Guide](https://www.familybrown.org/dokuwiki/doku.php?id=fester112:jails_plex#configure_a_mount_point) for one example), and log in to configure your media server.
+
+Note that if you are interested in using hardware transcode, there are [instructions for setting this up in FreeNAS 11.3](https://github.com/kern2011/Freenas-Quicksync).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ These values must be set.  They correspond to:
 
 Optional configuration values include:
 
-* USE_PLEXPASS - If set to 1, the script will download and install the beta version of Plex Media Server. Note that all PlexPass features are available in the stable version, as well. Defaults to 0.
+* USE_BETA - If set to 1, the script will download and install the beta version of Plex Media Server.  Defaults to 0.
 * PLEX_CONFIG_PATH - The path to store your Plex metadata and configuration.  Defaults to `$POOL_PATH/plex_data`.
 * NETMASK - The netmask, in bits, for the network the Plex jail will be on. Defaults to '24', which is '255.255.255.0'.
 
@@ -30,4 +30,4 @@ Note that if the script creates $PLEX_CONFIG_PATH, it will create it as a **dire
 
 Once you've prepared the configuration file, run the script by running `./plex-jail.sh`.  It should run for a few minutes and report completion.  You can then add storage to your jail as desired (see [Uncle Fester's Guide](https://www.familybrown.org/dokuwiki/doku.php?id=fester112:jails_plex#configure_a_mount_point) for one example), and log in to configure your media server.
 
-Note that if you are interested in using hardware transcode, there are [instructions for setting this up in FreeNAS 11.3](https://github.com/kern2011/Freenas-Quicksync).
+Note that if you are interested in hardware transcode, instructions for setting this up in FreeNAS 11.3 can be found at https://github.com/kern2011/Freenas-Quicksync .

--- a/configs/pkg.conf
+++ b/configs/pkg.conf
@@ -1,0 +1,1 @@
+ASSUME_ALWAYS_YES=true

--- a/plex-jail.sh
+++ b/plex-jail.sh
@@ -86,7 +86,7 @@ then
 	exit 1
 fi
 iocage exec "${JAIL_NAME}" rm /usr/local/etc/pkg.conf
-if [ $USE_PLEXPASS -eq 1 ]; then
+if [ $USE_BETA -eq 1 ]; then
   iocage exec "${JAIL_NAME}" sysrc plexmediaserver_plexpass_enable="YES"
   iocage exec "${JAIL_NAME}" sysrc plexmediaserver_plexpass_support_path="/config"
 else

--- a/plex-jail.sh
+++ b/plex-jail.sh
@@ -8,10 +8,13 @@ NETMASK=""
 VNET="on"
 POOL_PATH=""
 PLEX_CONFIG_PATH=""
+INTERFACE="vnet0"
 # BUGBUG In FreeNAS 11.3-U1, a 'plex' jail would not install pkg; any other name would
-# Until I understand how and why, side-stepping the issue with a default name of 'pms'
+# This was caused by the presence of another jail that had been named 'plex' at one
+# point. Might be CPE or FreeNAS. Since this script is used to migrate data off an
+# old plugin, side-stepping issue by naming jail 'pms'.  
 JAIL_NAME="pms"
-USE_PLEXPASS=0
+USE_BETA=0
 USE_BASEJAIL="-b"
 PLEXPKG=""
 
@@ -51,18 +54,15 @@ if [ -z "${PLEX_CONFIG_PATH}" ]; then
   PLEX_CONFIG_PATH="${POOL_PATH}"/plex_data
 fi
 
-if [ $USE_PLEXPASS -eq 1 ]; then
-	echo "Using beta-release plexmediaserver code as directed"
+if [ $USE_BETA -eq 1 ]; then
+	echo "Using beta-release plexmediaserver code"
 	PLEXPKG="plexmediaserver_plexpass"
 else
 	echo "Using stable-release plexmediaserver code"
 	PLEXPKG="plexmediaserver"
 fi
-
 # Create jail
-# BUGBUG Issue with devfs in FreeNAS 11.3-U1, restarting helps
-service devfs restart
-if ! iocage create --name "${JAIL_NAME}" -r "${RELEASE}" ip4_addr="${JAIL_IP}/${NETMASK}" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}" ${USE_BASEJAIL}
+if ! iocage create --name "${JAIL_NAME}" -r "${RELEASE}" ip4_addr="${INTERFACE}|${JAIL_IP}/${NETMASK}" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}" ${USE_BASEJAIL}
 then
 	echo "Failed to create jail"
 	exit 1

--- a/plex-jail.sh
+++ b/plex-jail.sh
@@ -4,12 +4,16 @@
 
 JAIL_IP=""
 DEFAULT_GW_IP=""
-INTERFACE="vnet0"
+NETMASK=""
 VNET="on"
 POOL_PATH=""
 PLEX_CONFIG_PATH=""
-JAIL_NAME="plex"
+# BUGBUG In FreeNAS 11.3-U1, a 'plex' jail would not install pkg; any other name would
+# Until I understand how and why, side-stepping the issue with a default name of 'pms'
+JAIL_NAME="pms"
 USE_PLEXPASS=0
+USE_BASEJAIL="-b"
+PLEXPKG=""
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "${SCRIPT}")
@@ -32,41 +36,37 @@ if [ -z "${DEFAULT_GW_IP}" ]; then
   echo 'Configuration error: DEFAULT_GW_IP must be set'
   exit 1
 fi
+if [ -z "${NETMASK}" ]; then
+  echo 'Netmask not set, defaulting to /24 (255.255.255.0)'
+  NETMASK="24"
+fi
+
 if [ -z "${POOL_PATH}" ]; then
   echo 'Configuration error: POOL_PATH must be set'
   exit 1
 fi
-
 # If PLEX_CONFIG_PATH isn't specified in plex-config, set it
 if [ -z "${PLEX_CONFIG_PATH}" ]; then
+  echo "Plex metadata path not set, defaulting to ${POOL_PATH}/plex_data"
   PLEX_CONFIG_PATH="${POOL_PATH}"/plex_data
 fi
 
 if [ $USE_PLEXPASS -eq 1 ]; then
-	cat <<__EOF__ >/tmp/pkg.json
-	{
-	  "pkgs":[
-	  "plexmediaserver-plexpass"
-	  ]
-	}
-__EOF__
+	echo "Using beta-release plexmediaserver code as directed"
+	PLEXPKG="plexmediaserver_plexpass"
 else
-	cat <<__EOF__ >/tmp/pkg.json
-	{
-	  "pkgs":[
-	  "plexmediaserver"
-	  ]
-	}
-__EOF__
+	echo "Using stable-release plexmediaserver code"
+	PLEXPKG="plexmediaserver"
 fi
 
 # Create jail
-if ! iocage create --name "${JAIL_NAME}" -p /tmp/pkg.json -r "${RELEASE}" ip4_addr="${INTERFACE}|${JAIL_IP}/24" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}"
+# BUGBUG Issue with devfs in FreeNAS 11.3-U1, restarting helps
+service devfs restart
+if ! iocage create --name "${JAIL_NAME}" -r "${RELEASE}" ip4_addr="${JAIL_IP}/${NETMASK}" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}" ${USE_BASEJAIL}
 then
 	echo "Failed to create jail"
 	exit 1
 fi
-rm /tmp/pkg.json
 
 iocage exec "${JAIL_NAME}" mkdir /config
 iocage exec "${JAIL_NAME}" mkdir /configs
@@ -77,6 +77,15 @@ mkdir -p "${PLEX_CONFIG_PATH}"
 chown -R 972:972 "${PLEX_CONFIG_PATH}"
 iocage fstab -a "${JAIL_NAME}" "${PLEX_CONFIG_PATH}" /config nullfs rw 0 0
 iocage fstab -a "${JAIL_NAME}" "${CONFIGS_PATH}" /configs nullfs rw 0 0
+iocage exec "${JAIL_NAME}" cp /configs/pkg.conf /usr/local/etc
+if ! iocage exec "${JAIL_NAME}" pkg install ${PLEXPKG}
+then
+	echo "Failed to install ${PLEXPKG} package"
+	iocage stop "${JAIL_NAME}"
+	iocage destroy -f "${JAIL_NAME}"
+	exit 1
+fi
+iocage exec "${JAIL_NAME}" rm /usr/local/etc/pkg.conf
 if [ $USE_PLEXPASS -eq 1 ]; then
   iocage exec "${JAIL_NAME}" sysrc plexmediaserver_plexpass_enable="YES"
   iocage exec "${JAIL_NAME}" sysrc plexmediaserver_plexpass_support_path="/config"
@@ -89,7 +98,6 @@ fi
 iocage exec "${JAIL_NAME}" crontab /configs/update_packages
 iocage fstab -r "${JAIL_NAME}" "${CONFIGS_PATH}" /configs nullfs rw 0 0
 iocage exec "${JAIL_NAME}" rm -rf /configs
-iocage exec "${JAIL_NAME}" pkg upgrade -y
 iocage restart "${JAIL_NAME}"
 
 echo "Installation Complete!"


### PR DESCRIPTION
A bunch of changes as I was trying to showcase your script in FreeNAS 11.3.

- Added NETMASK parameter
- Changed to default to a base jail - this is my preference, it seems 'cleaner' for long-running jails, revert at will
- Clarified README.md around PlexPass version, and added a note about hardware transcode
- Changed the default jail name to 'pms' from 'plex' - this is beyond bizarre, pkg would not install anything if the jail was named 'plex'. See forums, this may be my particular system, and it makes no sense to me, either.
- Removed the $INTERFACE when creating the jail, this plays merry hell with 11.3-U1. Have not tested this changed way of doing things against 11.2. That's worthwhile doing, maybe the code needs to branch depending on version
- Because of that pkg issue above, played around with how the pkg gets installed, and ultimately left it with the changes though they weren't the cause of things. It now installs from latest to begin with, instead of doing an upgrade - faster, less things get downloaded, users sees install notes. Can be reverted, if you hate the idea.