### PR TITLE
Changes for 11.3, speedup, and some clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ These values must be set.  They correspond to:
 
 Optional configuration values include:
 
-* USE_PLEXPASS - If set to 1, the script will download and install the PlexPass version of Plex Media Server.  Defaults to 0.
+* USE_BETA - If set to 1, the script will download and install the beta version of Plex Media Server.  Defaults to 0.
 * PLEX_CONFIG_PATH - The path to store your Plex metadata and configuration.  Defaults to `$POOL_PATH/plex_data`.
+* NETMASK - The netmask, in bits, for the network the Plex jail will be on. Defaults to '24', which is '255.255.255.0'.
 
 $PLEX_CONFIG_PATH need not exist before running this script; if it doesn't, the script will create it.  The script will also set ownership of that directory to the user/group IDs for Plex Media Server.  If this directory already exists, it **must not** be using Windows permissions.
 
 Note that if the script creates $PLEX_CONFIG_PATH, it will create it as a **directory**, not as a dataset.  This means that it will not appear in, e.g., the Storage section of the FreeNAS GUI, where you could easily see how much space it's using, compression ratio, etc.  If you want these capabilities, you should create the dataset before running the script, and then ensure that $PLEX_CONFIG_PATH is set appropriately.
 
 Once you've prepared the configuration file, run the script by running `./plex-jail.sh`.  It should run for a few minutes and report completion.  You can then add storage to your jail as desired (see [Uncle Fester's Guide](https://www.familybrown.org/dokuwiki/doku.php?id=fester112:jails_plex#configure_a_mount_point) for one example), and log in to configure your media server.
+
+Note that if you are interested in hardware transcode, instructions for setting this up in FreeNAS 11.3 can be found at https://github.com/kern2011/Freenas-Quicksync .

--- a/configs/pkg.conf
+++ b/configs/pkg.conf
@@ -1,0 +1,1 @@
+ASSUME_ALWAYS_YES=true


### PR DESCRIPTION
A number of changes as I was trying to showcase your script in FreeNAS 11.3.

Added NETMASK parameter

Changed to default to a base jail - this is my preference, it seems 'cleaner' for long-running jails, see discussion at  https://www.ixsystems.com/community/threads/iocage-jail-type-base-jail-vs-clone-which-to-choose.82639/

Clarified README.md around PlexPass version, renaming that to Beta, and added a note about hardware transcode

Changed the default jail name to 'pms' from 'plex' - this is beyond bizarre, pkg would not install anything if the jail was named 'plex' and there was a jail around that had been named 'plex' at some point. As this script may be used to migrate away from an existing plugin install, I changed the default jail name. Unclear whether issue is with FreeNAS 11.3-U1 or is being introduced by my CPE.

Because of that pkg issue above, played around with how the pkg gets installed, and ultimately left it with the changes though they weren't the cause of things. It now installs from latest to begin with, instead of doing an upgrade - faster, less things get downloaded, users sees install notes. Can be reverted, if you hate the idea.